### PR TITLE
Add parent directory replacement

### DIFF
--- a/helper/parser/placeholder.go
+++ b/helper/parser/placeholder.go
@@ -19,6 +19,10 @@ var placeholders = []placeholder{
 		key:   "current.dir",
 		value: getCurrentDir(),
 	},
+	{
+		key:   "parent.dir",
+		value: getParentDir(),
+	},
 }
 
 func getCurrentDir() string {
@@ -27,6 +31,16 @@ func getCurrentDir() string {
 		color.Red(err.Error())
 	}
 	return filepath.Base(path)
+}
+
+func getParentDir() string {
+	path, err := os.Getwd()
+	if err != nil {
+		color.Red(err.Error())
+		return ""
+	}
+	parentPath := filepath.Dir(path)
+	return filepath.Base(parentPath)
 }
 
 func getStringAfterSettingPlaceholderValues(input string) string {

--- a/helper/parser/placeholder_test.go
+++ b/helper/parser/placeholder_test.go
@@ -1,6 +1,8 @@
 package parser
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -18,8 +20,48 @@ func TestGetStringAfterSettingPlaceholderValuesMultiplePlaceholder(t *testing.T)
 	assert.Equal(t, "test/parser/test/parser", result)
 }
 
+func TestGetStringAfterSettingPlaceholderValuesParentDir(t *testing.T) {
+	result := getStringAfterSettingPlaceholderValues("test/{{parent.dir}}/test")
+
+	assert.Equal(t, "test/helper/test", result)
+}
+
 func TestGetCurrentDir(t *testing.T) {
 	result := getCurrentDir()
 
 	assert.Equal(t, "parser", result)
+}
+
+func TestGetParentDir(t *testing.T) {
+	result := getParentDir()
+
+	assert.Equal(t, "helper", result)
+}
+
+func TestParentDirPlaceholderWithTestFile(t *testing.T) {
+	// Read the test-parent.tfvars file
+	testFilePath := filepath.Join("..", "..", "test", "test-parent.tfvars")
+	content, err := os.ReadFile(testFilePath)
+	assert.NoError(t, err)
+
+	// Process the content to replace placeholders
+	processedContent := getStringAfterSettingPlaceholderValues(string(content))
+
+	// Check that parent.dir placeholders were replaced correctly
+	assert.Contains(t, processedContent, "helper-terraform-state")
+	assert.Contains(t, processedContent, "helper-lock-table")
+	assert.Contains(t, processedContent, "helper/terraform.tfstate")
+}
+
+func TestCombinedPlaceholdersWithTestFile(t *testing.T) {
+	// Read the test-parent-current-combined.tfvars file
+	testFilePath := filepath.Join("..", "..", "test", "test-parent-current-combined.tfvars")
+	content, err := os.ReadFile(testFilePath)
+	assert.NoError(t, err)
+
+	// Process the content to replace placeholders
+	processedContent := getStringAfterSettingPlaceholderValues(string(content))
+
+	// Check that both parent.dir and current.dir placeholders were replaced correctly
+	assert.Contains(t, processedContent, "terrastate/helper/parser/terraform.tfstate")
 }

--- a/test/test-parent-current-combined.tfvars
+++ b/test/test-parent-current-combined.tfvars
@@ -1,0 +1,17 @@
+# Terrastate - Parent and Current Directory Test
+
+state_backend = "s3"
+
+state_bucket = "local-test-bucket"
+
+state_dynamodb_table = "terraform-state-lock"
+
+region = "eu-central-1"
+
+state_key = "terrastate/{{ parent.dir }}/{{ current.dir }}/terraform.tfstate"
+
+state_auto_remove_old = true
+
+state_acl = "bucket-owner-full-control"
+
+stage = "test"

--- a/test/test-parent.tfvars
+++ b/test/test-parent.tfvars
@@ -1,0 +1,17 @@
+# Terrastate - Parent Directory Placeholder Test
+
+state_backend = "s3"
+
+state_bucket = "local-test-bucket"
+
+state_dynamodb_table = "terraform-state-lock"
+
+region = "eu-central-1"
+
+state_key = "terrastate/{{ parent.dir }}/terraform.tfstate"
+
+state_auto_remove_old = true
+
+state_acl = "bucket-owner-full-control"
+
+stage = "test"


### PR DESCRIPTION
I added a placeholder replacement for the paren.dir.

It follows the same logic as the current.dir replacement

In some cases it would have been helpful to have this replacement, so accidental missnaming or overwriting existing states after copying some files, could have been prevented.